### PR TITLE
Update depend

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,8 @@ parts:
             - --prefix=/
             - --disable-gtk-update-checks
         source: https://download.handbrake.fr/releases/1.2.2/HandBrake-1.2.2-source.tar.bz2
+        #source: https://github.com/HandBrake/HandBrake/releases/download/1.3.3/HandBrake-1.3.3-source.tar.bz2
+        #source-checksum: sha256/218a37d95f48b5e7cf285363d3ab16c314d97627a7a710cab3758902ae877f85
         build-packages:
             - g++
             - libtool-bin
@@ -99,6 +101,9 @@ parts:
             - libjansson4
             - gstreamer1.0-plugins-good
             - libslang2
+            - libgpm2
+            - libglu1
+            - freeglut3
         prime:
             - -share/applications
             - -share/doc


### PR DESCRIPTION
Snapcraft builds Handbrake version 1.2.2 (same as master) without any warnings.